### PR TITLE
FIRM28-1: Updated board ID code

### DIFF
--- a/Src/common/stm32/mcu/MCU.c
+++ b/Src/common/stm32/mcu/MCU.c
@@ -85,6 +85,15 @@ MCUBoard mcu_get_board() {
 
     if (uid.w0 == 0x3f0040 && uid.w1 == 0x31395114 && uid.w2 == 0x35393336) {
         return MCU_BOARD_NUCLEO_H743ZI2;
+    } else {
+        // If the UID is not matched, try to guess the board based on device ID
+        MCUDevID dev_id = mcu_get_dev_id();
+        if (dev_id == MCU_DEV_ID_STM32G471_473_474_483_484) {
+            return MCU_BOARD_NUCLEO_G474RE;
+        }
+        else if (dev_id == MCU_DEV_ID_STM32H742_743_753_750) {
+            return MCU_BOARD_NUCLEO_H743ZI2;
+        }
     }
 
     return MCU_BOARD_NONE;


### PR DESCRIPTION
Added a segment of code included in many Manual_Test files to get_board_id() in MCU.c for simplification. Will not be adding board UID as it's extra code that doesn't need to be added at the moment.